### PR TITLE
Update to TRIQS 3 and Python 3

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -4,7 +4,7 @@ Copyright (C) 2017, H. U.R. Strand
 
 The python module `pyed` implements exact diagonalization for finite fermionic many-body quantum systems, together with calculations of several response functions in imagianary time.
 
-The many-body system is defined using `pytriqs` second-quantized operators and the response functions are stored in `pytriqs` Green's function containters.
+The many-body system is defined using `triqs` second-quantized operators and the response functions are stored in `triqs` Green's function containters.
 
 The original purpose of `pyed` is to provide exact solutions to small finite systems, to be used as benchmarks and tests for stochastic many-body solvers.
 

--- a/benchmark/hubbard_atom_two_bathsites/calc.py
+++ b/benchmark/hubbard_atom_two_bathsites/calc.py
@@ -16,7 +16,7 @@ from triqs.gf import MeshImTime, MeshProduct
 from triqs.gf import GfImTime, GfImFreq
 
 from triqs.operators import c, c_dag
-from triqs.archive import HDFArchive
+from h5 import HDFArchive
 
 # ----------------------------------------------------------------------
 
@@ -67,8 +67,8 @@ if __name__ == '__main__':
                      statistic='Fermion', n_points=10,
                      target_shape=(1,1))
     
-    ed.set_g2_tau(g_tau, c(up,0), c_dag(up,0))
-    ed.set_g2_iwn(g_iwn, c(up,0), c_dag(up,0))
+    ed.set_g2_tau(g_tau[0,0], c(up,0), c_dag(up,0))
+    ed.set_g2_iwn(g_iwn[0,0], c(up,0), c_dag(up,0))
 
     # ------------------------------------------------------------------
     # -- Two particle Green's functions
@@ -80,15 +80,15 @@ if __name__ == '__main__':
     g40_tau = Gf(name='g40_tau', mesh=prodmesh, target_shape=[1, 1, 1, 1])
     g4_tau = Gf(name='g4_tau', mesh=prodmesh, target_shape=[1, 1, 1, 1])
 
-    ed.set_g40_tau(g40_tau, g_tau)
-    ed.set_g4_tau(g4_tau, c(up,0), c_dag(up,0), c(up,0), c_dag(up,0))
+    ed.set_g40_tau(g40_tau, g_tau[0,0])
+    ed.set_g4_tau(g4_tau[0,0,0,0], c(up,0), c_dag(up,0), c(up,0), c_dag(up,0))
 
     # ------------------------------------------------------------------
     # -- Two particle Green's functions (equal times)
 
     prodmesh = MeshProduct(imtime, imtime)
     g3pp_tau = Gf(name='g4_tau', mesh=prodmesh, target_shape=[1, 1, 1, 1])
-    ed.set_g3_tau(g3pp_tau, c(up,0), c_dag(up,0), c(up,0)*c_dag(up,0))
+    ed.set_g3_tau(g3pp_tau[0,0,0,0], c(up,0), c_dag(up,0), c(up,0)*c_dag(up,0))
 
     # ------------------------------------------------------------------
     # -- Store to hdf5

--- a/benchmark/hubbard_atom_two_bathsites/calc.py
+++ b/benchmark/hubbard_atom_two_bathsites/calc.py
@@ -11,12 +11,12 @@ import numpy as np
 
 # ----------------------------------------------------------------------
 
-from pytriqs.gf import Gf
-from pytriqs.gf import MeshImTime, MeshProduct
-from pytriqs.gf import GfImTime, GfImFreq
+from triqs.gf import Gf
+from triqs.gf import MeshImTime, MeshProduct
+from triqs.gf import GfImTime, GfImFreq
 
-from pytriqs.operators import c, c_dag
-from pytriqs.archive import HDFArchive
+from triqs.operators import c, c_dag
+from triqs.archive import HDFArchive
 
 # ----------------------------------------------------------------------
 

--- a/benchmark/hubbard_atom_two_bathsites/plot.py
+++ b/benchmark/hubbard_atom_two_bathsites/plot.py
@@ -11,7 +11,7 @@ import matplotlib.pyplot as plt
 # ----------------------------------------------------------------------
 
 from triqs.gf import Gf
-from triqs.archive import HDFArchive
+from h5 import HDFArchive
 #from triqs.plot.mpl_interface import oplot
 
 # ----------------------------------------------------------------------

--- a/benchmark/hubbard_atom_two_bathsites/plot.py
+++ b/benchmark/hubbard_atom_two_bathsites/plot.py
@@ -93,7 +93,7 @@ if __name__ == '__main__':
     subp = [1, 3, 1]
     
     # -- All slice planes
-    for i1, i2 in itertools.combinations(range(3), 2):
+    for i1, i2 in itertools.combinations(list(range(3)), 2):
 
         frac_cut = 3
         cut_idx = int(np.round(1./frac_cut * g4_tau.data.shape[0]))

--- a/benchmark/hubbard_atom_two_bathsites/plot.py
+++ b/benchmark/hubbard_atom_two_bathsites/plot.py
@@ -10,9 +10,9 @@ import matplotlib.pyplot as plt
 
 # ----------------------------------------------------------------------
 
-from pytriqs.gf import Gf
-from pytriqs.archive import HDFArchive
-#from pytriqs.plot.mpl_interface import oplot
+from triqs.gf import Gf
+from triqs.archive import HDFArchive
+#from triqs.plot.mpl_interface import oplot
 
 # ----------------------------------------------------------------------
 

--- a/benchmark/non_interacting_dimer/Non-interacting dimer tutorial.ipynb
+++ b/benchmark/non_interacting_dimer/Non-interacting dimer tutorial.ipynb
@@ -33,7 +33,7 @@
     }
    ],
    "source": [
-    "from pytriqs.operators import c, c_dag\n",
+    "from triqs.operators import c, c_dag\n",
     "up, do = 0, 1\n",
     "\n",
     "V = 1.0\n",
@@ -100,9 +100,9 @@
    ],
    "source": [
     "import itertools\n",
-    "from pytriqs.gf import GfImTime\n",
+    "from triqs.gf import GfImTime\n",
     "import matplotlib.pyplot as plt\n",
-    "from pytriqs.plot.mpl_interface import oplot\n",
+    "from triqs.plot.mpl_interface import oplot\n",
     "\n",
     "plt.figure(figsize=(8, 6))\n",
     "subp = [2, 2, 1]\n",

--- a/benchmark/non_interacting_dimer/Non-interacting dimer tutorial.ipynb
+++ b/benchmark/non_interacting_dimer/Non-interacting dimer tutorial.ipynb
@@ -28,7 +28,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "H = -1*C^+(0,0)C(0,1) + -1*C^+(0,1)C(0,0) + -1*C^+(1,0)C(1,1) + -1*C^+(1,1)C(1,0)\n"
+      "H = -1*c_dag(0,0)*c(0,1) + -1*c_dag(0,1)*c(0,0) + -1*c_dag(1,0)*c(1,1) + -1*c_dag(1,1)*c(1,0)\n"
      ]
     }
    ],
@@ -40,7 +40,7 @@
     "H = -V*(c_dag(up, 0)*c(up, 1) + c_dag(up, 1)*c(up, 0) + \\\n",
     "        c_dag(do, 0)*c(do, 1) + c_dag(do, 1)*c(do, 0) )\n",
     "\n",
-    "print 'H =', H"
+    "print('H =', H)"
    ]
   },
   {
@@ -59,20 +59,20 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Z = 1.00018161209\n",
-      "\\Omega = -2.00001815956\n"
+      "Z = 1.000181612086346\n",
+      "\\Omega = -2.0000181595596866\n"
      ]
     }
    ],
    "source": [
     "beta = 10.0 # inverse temperature\n",
-    "fundamental_operators = [c(up, 0), c(down, 0), c(up, 1), c(down, 1)]\n",
+    "fundamental_operators = [c(up, 0), c(do, 0), c(up, 1), c(do, 1)]\n",
     "\n",
     "from pyed.TriqsExactDiagonalization import TriqsExactDiagonalization\n",
     "ed = TriqsExactDiagonalization(H, fundamental_operators, beta)\n",
     "\n",
-    "print r'Z =', ed.get_partition_function()\n",
-    "print r'\\Omega =', ed.get_free_energy()"
+    "print(r'Z =', ed.get_partition_function())\n",
+    "print(r'\\Omega =', ed.get_free_energy())"
    ]
   },
   {
@@ -109,7 +109,7 @@
     "for i1, i2 in itertools.product(range(2), repeat=2):\n",
     "    g_tau = GfImTime(name=r'$g_{%i%i}$' % (i1, i2), beta=beta, \n",
     "                     statistic='Fermion', n_points=50, target_shape=(1,1))\n",
-    "    ed.set_g2_tau(g_tau, c(up, i1), c_dag(up, i2))\n",
+    "    ed.set_g2_tau(g_tau[0,0], c(up, i1), c_dag(up, i2))\n",
     "    plt.subplot(*subp); subp[-1] += 1\n",
     "    oplot(g_tau)\n",
     "    \n",
@@ -184,14 +184,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "H = -1*C^+(0,0)C(0,0) + 1*C^+(0,1)C(0,1) + -1*C^+(1,0)C(1,0) + 1*C^+(1,1)C(1,1)\n"
+      "H = -1*c_dag(0,0)*c(0,0) + 1*c_dag(0,1)*c(0,1) + -1*c_dag(1,0)*c(1,0) + 1*c_dag(1,1)*c(1,1)\n"
      ]
     }
    ],
    "source": [
     "H = -V*(c_dag(up, 0)*c(up, 0) + c_dag(do, 0)*c(do, 0)) + \\\n",
     "    +V*(c_dag(up, 1)*c(up, 1) + c_dag(do, 1)*c(do, 1))\n",
-    "print 'H =', H\n",
+    "print('H =', H)\n",
     "ed = TriqsExactDiagonalization(H, fundamental_operators, beta)\n",
     "\n"
    ]
@@ -222,7 +222,7 @@
     "for i1, i2 in itertools.product(range(2), repeat=2):\n",
     "    g_tau = GfImTime(name=r'$g_{%i%i}$' % (i1, i2), beta=beta, \n",
     "                     statistic='Fermion', n_points=50, target_shape=(1,1))\n",
-    "    ed.set_g2_tau(g_tau, c(up, i1), c_dag(up, i2))\n",
+    "    ed.set_g2_tau(g_tau[0,0], c(up, i1), c_dag(up, i2))\n",
     "    gmat[i1, i2] = g_tau\n",
     "    plt.subplot(*subp); subp[-1] += 1\n",
     "    oplot(g_tau)\n",
@@ -298,21 +298,21 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 2",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "python2"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.13"
+   "pygments_lexer": "ipython3",
+   "version": "3.8.5"
   }
  },
  "nbformat": 4,

--- a/benchmark/spinless/calc.py
+++ b/benchmark/spinless/calc.py
@@ -73,7 +73,7 @@ if __name__ == '__main__':
                      indices=['A', 'B'])
 
     for (i1, s1), (i2, s2) in itertools.product([('A', up), ('B', do)], repeat=2):
-        print i1, s1, i2, s2
+        print(i1, s1, i2, s2)
         ed.set_g2_tau(g_tau[i1, i2], c(s1,0), c_dag(s2,0))
 
     # ------------------------------------------------------------------

--- a/benchmark/spinless/calc.py
+++ b/benchmark/spinless/calc.py
@@ -14,12 +14,12 @@ import numpy as np
 
 # ----------------------------------------------------------------------
 
-from pytriqs.gf import Gf
-from pytriqs.gf import MeshImTime, MeshProduct
-from pytriqs.gf import GfImTime, GfImFreq
+from triqs.gf import Gf
+from triqs.gf import MeshImTime, MeshProduct
+from triqs.gf import GfImTime, GfImFreq
 
-from pytriqs.operators import c, c_dag
-from pytriqs.archive import HDFArchive
+from triqs.operators import c, c_dag
+from triqs.archive import HDFArchive
 
 # ----------------------------------------------------------------------
 

--- a/benchmark/spinless/calc.py
+++ b/benchmark/spinless/calc.py
@@ -19,7 +19,7 @@ from triqs.gf import MeshImTime, MeshProduct
 from triqs.gf import GfImTime, GfImFreq
 
 from triqs.operators import c, c_dag
-from triqs.archive import HDFArchive
+from h5 import HDFArchive
 
 # ----------------------------------------------------------------------
 

--- a/benchmark/spinless/plot.py
+++ b/benchmark/spinless/plot.py
@@ -10,7 +10,7 @@ import matplotlib.pyplot as plt
 # ----------------------------------------------------------------------
 
 from triqs.gf import Gf
-from triqs.archive import HDFArchive
+from h5 import HDFArchive
 from triqs.plot.mpl_interface import oplotr
 
 # ----------------------------------------------------------------------

--- a/benchmark/spinless/plot.py
+++ b/benchmark/spinless/plot.py
@@ -9,9 +9,9 @@ import matplotlib.pyplot as plt
 
 # ----------------------------------------------------------------------
 
-from pytriqs.gf import Gf
-from pytriqs.archive import HDFArchive
-from pytriqs.plot.mpl_interface import oplotr
+from triqs.gf import Gf
+from triqs.archive import HDFArchive
+from triqs.plot.mpl_interface import oplotr
 
 # ----------------------------------------------------------------------
 if __name__ == '__main__':

--- a/doc/Documentation.ipynb
+++ b/doc/Documentation.ipynb
@@ -10,7 +10,7 @@
     "\n",
     "The python module `pyed` implements exact diagonalization for finite fermionic many-body quantum systems, together with calculations of several response functions in imagianary time.\n",
     "\n",
-    "The many-body system is defined using `pytriqs` second-quantized operators and the response functions are stored in `pytriqs` Green's function containters.\n",
+    "The many-body system is defined using `triqs` second-quantized operators and the response functions are stored in `triqs` Green's function containters.\n",
     "\n",
     "## Hamiltonians\n",
     "\n",
@@ -31,7 +31,7 @@
     }
    ],
    "source": [
-    "from pytriqs.operators import c, c_dag\n",
+    "from triqs.operators import c, c_dag\n",
     "up, down = 0, 1\n",
     "n_up = c_dag(up, 0) * c(up, 0)\n",
     "n_down = c_dag(down, 0) * c(down, 0)\n",
@@ -147,7 +147,7 @@
     "$$\n",
     "where the imaginary time dependent operators are defined in the Heisenberg picture $c_{\\sigma}(\\tau) \\equiv e^{\\tau H} c_{\\sigma} e^{-\\tau H}$ and $c^\\dagger_{\\sigma}(\\tau) \\equiv e^{\\tau H} c^\\dagger_{\\sigma} e^{-\\tau H}$.\n",
     "\n",
-    "To calculate $G(\\tau)$ we first create `pytriqs.GfImTime` instance to store the result and pass it to our ED solver instance:"
+    "To calculate $G(\\tau)$ we first create `triqs.GfImTime` instance to store the result and pass it to our ED solver instance:"
    ]
   },
   {
@@ -158,12 +158,12 @@
    },
    "outputs": [],
    "source": [
-    "from pytriqs.gf import GfImTime\n",
+    "from triqs.gf import GfImTime\n",
     "g_tau = GfImTime(name=r'$g$', beta=beta, statistic='Fermion', n_points=50, target_shape=(1,1))    \n",
     "ed.set_g2_tau(g_tau, c(up,0), c_dag(up,0))\n",
     "\n",
     "import matplotlib.pyplot as plt\n",
-    "from pytriqs.plot.mpl_interface import oplot\n",
+    "from triqs.plot.mpl_interface import oplot\n",
     "\n",
     "plt.figure(); oplot(g_tau); plt.savefig('figure_g_tau.png')"
    ]
@@ -191,7 +191,7 @@
    },
    "outputs": [],
    "source": [
-    "from pytriqs.gf import GfImTime\n",
+    "from triqs.gf import GfImTime\n",
     "densdens_tau = GfImTime(name=r'$\\langle n(\\tau) n(0) \\rangle$', beta=beta, statistic='Boson', n_points=50, target_shape=(1,1))    \n",
     "ed.set_g2_tau(densdens_tau, n_up, n_down)\n",
     "\n",
@@ -227,7 +227,7 @@
    },
    "outputs": [],
    "source": [
-    "from pytriqs.gf import GfImFreq\n",
+    "from triqs.gf import GfImFreq\n",
     "g_iwn = GfImFreq(name=r'$g$', beta=beta, statistic='Fermion', n_points=10, target_shape=(1,1))\n",
     "ed.set_g2_iwn(g_iwn, c(up,0), c_dag(up,0))\n",
     "\n",
@@ -258,7 +258,7 @@
     "c_\\gamma(\\tau_3) c^\\dagger_{\\bar{\\delta}} (0)  \\rangle\n",
     "$$\n",
     "\n",
-    "That easily can be calculated with `pyed` by passing a suitable `pytriqs` container to the ED solver:\n"
+    "That easily can be calculated with `pyed` by passing a suitable `triqs` container to the ED solver:\n"
    ]
   },
   {
@@ -267,8 +267,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from pytriqs.gf import Gf\n",
-    "from pytriqs.gf import MeshImTime, MeshProduct\n",
+    "from triqs.gf import Gf\n",
+    "from triqs.gf import MeshImTime, MeshProduct\n",
     "\n",
     "ntau = 10\n",
     "imtime = MeshImTime(beta, 'Fermion', ntau)\n",

--- a/doc/Documentation.ipynb
+++ b/doc/Documentation.ipynb
@@ -26,7 +26,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "H = -0.1*C^+(0,0)C(0,0) + -0.1*C^+(1,0)C(1,0) + 1*C^+(0,0)C^+(1,0)C(1,0)C(0,0)\n"
+      "H = -0.1*c_dag(0,0)*c(0,0) + -0.1*c_dag(1,0)*c(1,0) + 1*c_dag(0,0)*c_dag(1,0)*c(1,0)*c(0,0)\n"
      ]
     }
    ],
@@ -41,7 +41,7 @@
     "\n",
     "H = U * n_up * n_down - mu * (n_up + n_down)\n",
     "\n",
-    "print 'H =', H"
+    "print('H =', H)"
    ]
   },
   {
@@ -74,13 +74,13 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Z = 2.9840296413\n",
-      "\\Omega = -0.646637307852\n",
+      "Z = 2.984029641299568\n",
+      "\\Omega = -0.6466373078517809\n",
       "\\rho =\n",
-      "[[ 0.27437085  0.          0.          0.        ]\n",
-      " [ 0.          0.33511731  0.          0.        ]\n",
-      " [ 0.          0.          0.33511731  0.        ]\n",
-      " [ 0.          0.          0.          0.05539452]]\n"
+      "[[0.27437085 0.         0.         0.        ]\n",
+      " [0.         0.33511731 0.         0.        ]\n",
+      " [0.         0.         0.33511731 0.        ]\n",
+      " [0.         0.         0.         0.05539452]]\n"
      ]
     }
    ],
@@ -91,10 +91,10 @@
     "from pyed.TriqsExactDiagonalization import TriqsExactDiagonalization\n",
     "ed = TriqsExactDiagonalization(H, fundamental_operators, beta)\n",
     "\n",
-    "print r'Z =', ed.get_partition_function()\n",
-    "print r'\\Omega =', ed.get_free_energy()\n",
-    "print r'\\rho ='\n",
-    "print ed.ed.get_density_matrix()"
+    "print(r'Z =', ed.get_partition_function())\n",
+    "print(r'\\Omega =', ed.get_free_energy())\n",
+    "print(r'\\rho =')\n",
+    "print(ed.ed.get_density_matrix())"
    ]
   },
   {
@@ -119,16 +119,16 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "<n_up>   = 0.390511834096\n",
-      "<n_down> = 0.390511834096\n",
-      "<n_up * n_down> = 0.0553945195228\n"
+      "<n_up>   = 0.3905118340962893\n",
+      "<n_down> = 0.3905118340962893\n",
+      "<n_up * n_down> = 0.05539451952280125\n"
      ]
     }
    ],
    "source": [
-    "print '<n_up>   =', ed.get_expectation_value(n_up)\n",
-    "print '<n_down> =', ed.get_expectation_value(n_down)\n",
-    "print '<n_up * n_down> =', ed.get_expectation_value(n_up * n_down)"
+    "print('<n_up>   =', ed.get_expectation_value(n_up))\n",
+    "print('<n_down> =', ed.get_expectation_value(n_down))\n",
+    "print('<n_up * n_down> =', ed.get_expectation_value(n_up * n_down))"
    ]
   },
   {
@@ -159,8 +159,8 @@
    "outputs": [],
    "source": [
     "from triqs.gf import GfImTime\n",
-    "g_tau = GfImTime(name=r'$g$', beta=beta, statistic='Fermion', n_points=50, target_shape=(1,1))    \n",
-    "ed.set_g2_tau(g_tau, c(up,0), c_dag(up,0))\n",
+    "g_tau = GfImTime(name=r'$g$', beta=beta, statistic='Fermion', n_points=50, target_shape=(1,1))\n",
+    "ed.set_g2_tau(g_tau[0,0], c(up,0), c_dag(up,0))\n",
     "\n",
     "import matplotlib.pyplot as plt\n",
     "from triqs.plot.mpl_interface import oplot\n",
@@ -192,8 +192,8 @@
    "outputs": [],
    "source": [
     "from triqs.gf import GfImTime\n",
-    "densdens_tau = GfImTime(name=r'$\\langle n(\\tau) n(0) \\rangle$', beta=beta, statistic='Boson', n_points=50, target_shape=(1,1))    \n",
-    "ed.set_g2_tau(densdens_tau, n_up, n_down)\n",
+    "densdens_tau = GfImTime(name=r'$\\langle n(\\tau) n(0) \\rangle$', beta=beta, statistic='Boson', n_points=50, target_shape=(1,1))\n",
+    "ed.set_g2_tau(densdens_tau[0,0], n_up, n_down)\n",
     "\n",
     "plt.figure(); oplot(densdens_tau); plt.savefig('figure_densdens_tau.png')"
    ]
@@ -229,7 +229,7 @@
    "source": [
     "from triqs.gf import GfImFreq\n",
     "g_iwn = GfImFreq(name=r'$g$', beta=beta, statistic='Fermion', n_points=10, target_shape=(1,1))\n",
-    "ed.set_g2_iwn(g_iwn, c(up,0), c_dag(up,0))\n",
+    "ed.set_g2_iwn(g_iwn[0,0], c(up,0), c_dag(up,0))\n",
     "\n",
     "plt.figure(); oplot(g_iwn); plt.savefig('figure_g_iwn.png')"
    ]
@@ -275,7 +275,7 @@
     "prodmesh = MeshProduct(imtime, imtime, imtime)\n",
     "\n",
     "g4_tau = Gf(name=r'$G^{(4)}(\\tau_1,\\tau_2,\\tau_3)$', mesh=prodmesh, target_shape=[1, 1, 1, 1])\n",
-    "ed.set_g4_tau(g4_tau, c(up,0), c_dag(up,0), c(up,0), c_dag(up,0))"
+    "ed.set_g4_tau(g4_tau[0,0,0,0], c(up,0), c_dag(up,0), c(up,0), c_dag(up,0))"
    ]
   },
   {
@@ -304,7 +304,7 @@
    "source": [
     "prodmesh2 = MeshProduct(imtime, imtime)\n",
     "g3pp_tau = Gf(name=r'$G^{(3)}(\\tau_1, \\tau_2)$', mesh=prodmesh2, target_shape=[1, 1, 1, 1])\n",
-    "ed.set_g3_tau(g3pp_tau, c(up,0), c_dag(up,0), c(up,0)*c_dag(up,0))"
+    "ed.set_g3_tau(g3pp_tau[0,0,0,0], c(up,0), c_dag(up,0), c(up,0)*c_dag(up,0))"
    ]
   },
   {
@@ -326,7 +326,7 @@
     "fig = plt.figure(figsize=(3.25*2, 2*2.5))\n",
     "ax = fig.add_subplot(1,1,1, projection='3d')\n",
     "\n",
-    "data = g3pp_tau.data[:, :, 0, 0, 0, 0]\n",
+    "data = g3pp_tau.data[:,:,0,0,0,0]\n",
     "tau = [tau.value.real for tau in g3pp_tau.mesh.components[0]]\n",
     "t1, t2 = np.meshgrid(tau, tau)\n",
     "ax.plot_wireframe(t1, t2, data.real)\n",
@@ -347,21 +347,21 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 2",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "python2"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.13"
+   "pygments_lexer": "ipython3",
+   "version": "3.8.5"
   }
  },
  "nbformat": 4,

--- a/pyed/CubeTetras.py
+++ b/pyed/CubeTetras.py
@@ -84,13 +84,13 @@ class CubeTetras(CubeTetrasBase):
     # ------------------------------------------------------------------
     def __iter__(self):
 
-        for tidx in xrange(6):
+        for tidx in range(6):
             
             func, perm, perm_sign = self.tetra_list[tidx]
     
             index = []
             for n1, n2, n3 in itertools.product(
-                    range(self.ntau), repeat=3):
+                    list(range(self.ntau)), repeat=3):
                 if func(n1, n2, n3): index.append((n1, n2, n3))
 
             index = np.array(index).T
@@ -122,8 +122,8 @@ class CubeTetrasMesh(CubeTetrasBase):
 
         """ for triqs three time greens functions """
 
-        tetra_idx = [ [] for n in xrange(6) ]
-        tetra_tau = [ [] for n in xrange(6) ]
+        tetra_idx = [ [] for n in range(6) ]
+        tetra_tau = [ [] for n in range(6) ]
 
         for idxs, taus in enumerate_tau3(self.g4_tau):
             
@@ -135,7 +135,7 @@ class CubeTetrasMesh(CubeTetrasBase):
                     tetra_tau[tidx] += [ taus ]
                     break
 
-        for tidx in xrange(6):
+        for tidx in range(6):
             func, perm, perm_sign = self.tetra_list[tidx]
 
             yield tetra_idx[tidx], tetra_tau[tidx], perm, perm_sign

--- a/pyed/CubeTetras.py
+++ b/pyed/CubeTetras.py
@@ -13,13 +13,13 @@ import numpy as np
 
 # ----------------------------------------------------------------------
 def Idxs(integer_index_list):
-    from pytriqs.gf import Idx
+    from triqs.gf import Idx
     return tuple( Idx(i) for i in integer_index_list )
 
 # ----------------------------------------------------------------------
 def zero_outer_planes_and_equal_times(g4_tau):
 
-    from pytriqs.gf import Idx
+    from triqs.gf import Idx
     beta = g4_tau.mesh.components[0].beta
     
     for idxs, (t1, t2, t3) in enumerate_tau3(g4_tau):
@@ -32,7 +32,7 @@ def zero_outer_planes_and_equal_times(g4_tau):
 # ----------------------------------------------------------------------
 def enumerate_tau3(g4_tau, make_real=True, beta=None):
 
-    from pytriqs.gf import MeshImTime, MeshProduct
+    from triqs.gf import MeshImTime, MeshProduct
     
     assert( type(g4_tau.mesh) == MeshProduct )
 
@@ -120,7 +120,7 @@ class CubeTetrasMesh(CubeTetrasBase):
     # ------------------------------------------------------------------
     def __iter__(self):
 
-        """ for pytriqs three time greens functions """
+        """ for triqs three time greens functions """
 
         tetra_idx = [ [] for n in xrange(6) ]
         tetra_tau = [ [] for n in xrange(6) ]

--- a/pyed/OperatorUtils.py
+++ b/pyed/OperatorUtils.py
@@ -9,7 +9,7 @@ Author: Hugo U.R. Strand (2018) hugo.strand@gmail.com """
 import itertools
 import numpy as np
 
-from pytriqs.operators import c, c_dag, Operator, dagger
+from triqs.operators import c, c_dag, Operator, dagger
 
 # ----------------------------------------------------------------------    
 def fundamental_operators_from_gf_struct(gf_struct):

--- a/pyed/OperatorUtils.py
+++ b/pyed/OperatorUtils.py
@@ -128,7 +128,7 @@ def quartic_pauli_symmetrize(U):
     N = U.shape[0]
     assert( U.shape == tuple([N]*4) )
 
-    for n in xrange(N):
+    for n in range(N):
         U[n, n, :, :] = 0
         U[:, :, n, n] = 0
 
@@ -179,7 +179,7 @@ def quartic_tensor_from_operator(op, fundamental_operators,
         op_list, prefactor = term
         if len(op_list) == 4:
 
-            d, t = zip(*op_list) # split in two lists with daggers and tuples resp
+            d, t = list(zip(*op_list)) # split in two lists with daggers and tuples resp
             t = [tuple(x) for x in t]
 
             # check creation/annihilation order
@@ -217,7 +217,7 @@ def operator_from_quartic_tensor(h_quart, fundamental_operators):
     H = Operator(0.)
 
     for t in itertools.product(enumerate(fundamental_operators), repeat=4):
-        idx, ops = zip(*t)
+        idx, ops = list(zip(*t))
         o1, o2, o3, o4 = ops
         o1, o2 = dagger(o1), dagger(o2)
 
@@ -246,7 +246,7 @@ def operator_single_particle_transform(op, U, fundamental_operators):
         k = op_idx_map.index((s, i))
         
         ret = Operator()
-        for l in xrange(U.shape[0]):
+        for l in range(U.shape[0]):
             op_idx = op_idx_map[l]
             ret += U[k, l] * c(*op_idx)
 
@@ -271,7 +271,7 @@ def operator_single_particle_transform(op, U, fundamental_operators):
             if type(factor) is list:
                 for dag, idxs in factor:
                     tup = (dag, tuple(idxs))
-                    if tup in op_trans_dict.keys():
+                    if tup in list(op_trans_dict.keys()):
                         op_factor *= op_trans_dict[tup]
                     else:
                         op_factor *= {False:c, True:c_dag}[dag](*idxs)

--- a/pyed/ParameterCollection.py
+++ b/pyed/ParameterCollection.py
@@ -28,10 +28,10 @@ class ParameterCollection(object):
         self.__dict__.update(kwargs)
 
     def items(self):
-        return self.__dict__.items()
+        return list(self.__dict__.items())
 
     def keys(self):
-   	return self.__dict__.keys()
+   	return list(self.__dict__.keys())
 
     def dict(self):
         return self.__dict__
@@ -46,7 +46,7 @@ class ParameterCollection(object):
         """ Fix for bug in Triqs that cast bool to numpy.bool_ 
         here we cast all numpy.bools_ to plain python bools """
         
-        for key, value in self.items():
+        for key, value in list(self.items()):
             if type(value) == np.bool_:
                 self.dict()[key] = bool(value)
 
@@ -57,7 +57,7 @@ class ParameterCollection(object):
 
         d = self.dict()[dict_key]
         d_fix = {}
-        for key, value in d.items():
+        for key, value in list(d.items()):
             d_fix[eval(key)] = value            
         self.dict()[dict_key] = d_fix
     
@@ -75,7 +75,7 @@ class ParameterCollection(object):
 
     def __str__(self):
         out = ''
-        keys = np.sort(self.__dict__.keys()) # sort keys
+        keys = np.sort(list(self.__dict__.keys())) # sort keys
         for key in keys:
             value = self.__dict__[key]
             if type(value) is ParameterCollection:
@@ -97,8 +97,8 @@ class ParameterCollection(object):
     def get_my_name(self):
         ans = []
         frame = inspect.currentframe().f_back
-        tmp = dict(frame.f_globals.items() + frame.f_locals.items())
-        for k, var in tmp.items():
+        tmp = dict(list(frame.f_globals.items()) + list(frame.f_locals.items()))
+        for k, var in list(tmp.items()):
             if isinstance(var, self.__class__):
                 if hash(self) == hash(var):
                     ans.append(k)

--- a/pyed/ParameterCollection.py
+++ b/pyed/ParameterCollection.py
@@ -51,7 +51,7 @@ class ParameterCollection(object):
                 self.dict()[key] = bool(value)
 
     def convert_keys_from_string_to_python(self, dict_key):
-        """ pytriqs.archive.HDFArchive incorrectly mangles tuple keys to string
+        """ triqs.archive.HDFArchive incorrectly mangles tuple keys to string
         running this on the affected dict tries to revert this by running eval
         on the string representation. UGLY FIX... """
 
@@ -107,5 +107,5 @@ class ParameterCollection(object):
 
 # -- Register ParameterCollection in Triqs hdf_archive_schemes
 
-from pytriqs.archive.hdf_archive_schemes import register_class 
+from triqs.archive.hdf_archive_schemes import register_class 
 register_class(ParameterCollection)

--- a/pyed/SparseExactDiagonalization.py
+++ b/pyed/SparseExactDiagonalization.py
@@ -19,7 +19,7 @@ from scipy.sparse.linalg import eigsh as eigsh_sparse
 
 # ----------------------------------------------------------------------
 
-from CubeTetras import CubeTetras
+from .CubeTetras import CubeTetras
 
 # ----------------------------------------------------------------------
 class SparseExactDiagonalization(object):
@@ -59,7 +59,7 @@ class SparseExactDiagonalization(object):
                 self.E, self.U = eigsh_sparse(
                     self.H, k=self.nstates, which='SA',
                     v0=self.v0, tol=self.tol, ncv=self.nstates*8+1)
-                print 'ED:', time.time() - t, ' s'
+                print('ED:', time.time() - t, ' s')
             else:
                 self.E, self.U = eigs_sparse(
                     self.H, k=self.nstates, which='SR',
@@ -95,7 +95,7 @@ class SparseExactDiagonalization(object):
     def get_expectation_value_sparse(self, operator):
 
         exp_val = 0.0
-        for idx in xrange(self.E.size):
+        for idx in range(self.E.size):
             vec = self.U[:, idx]
             dot_prod = np.dot(vec.H, operator * vec)[0,0] # <n|O|n>
             exp_val += np.exp(-self.beta * self.E[idx]) * dot_prod
@@ -208,7 +208,7 @@ class SparseExactDiagonalization(object):
         for tidx, tetra in enumerate(CubeTetras(tau)):
             idx, taus, perm, perm_sign = tetra
 
-            print 'Tetra:', tidx
+            print('Tetra:', tidx)
             
             # do not permute the last operator
             ops_perm = ops[perm + [3]]
@@ -400,7 +400,7 @@ class SparseExactDiagonalization(object):
         ba, bc = op1, op2
 
         Hba = ba
-        for order in xrange(Norder):
+        for order in range(Norder):
             tail_op = xi_commutator(Hba, bc, xi)                
             Gc[order] = (-1.)**(order) * \
                         self.get_expectation_value(tail_op)

--- a/pyed/SparseMatrixFockStates.py
+++ b/pyed/SparseMatrixFockStates.py
@@ -86,7 +86,7 @@ class SparseMatrixRepresentation(object):
         from sympy.simplify.simplify import nsimplify
         
         d = dict([ ((i, j), nsimplify(val)) \
-                   for (i, j), val in Hsp.todok().iteritems() ])
+                   for (i, j), val in Hsp.todok().items() ])
         
         H = SparseMatrix(Hsp.shape[0], Hsp.shape[1], d)
 
@@ -105,7 +105,7 @@ class SparseMatrixCreationOperators:
         self.nstates = 2**nfermions
 
         self.c_dag = []
-        for fidx in xrange(nfermions):
+        for fidx in range(nfermions):
             c_dag_fidx = self._build_creation_operator(fidx)
             self.c_dag.append(c_dag_fidx)
 

--- a/pyed/SquareTriangles.py
+++ b/pyed/SquareTriangles.py
@@ -25,7 +25,7 @@ def zero_outer_planes_and_equal_times(g3_tau):
 # ----------------------------------------------------------------------
 def enumerate_tau2(g3_tau, make_real=True, beta=None):
 
-    from pytriqs.gf import MeshImTime, MeshProduct
+    from triqs.gf import MeshImTime, MeshProduct
     
     assert( type(g3_tau.mesh) == MeshProduct )
 
@@ -110,7 +110,7 @@ class SquareTrianglesMesh(SquareTrianglesBase):
     # ------------------------------------------------------------------
     def __iter__(self):
 
-        """ for pytriqs three time greens functions """
+        """ for triqs three time greens functions """
 
         triangle_idx = [ [] for n in xrange(self.N) ]
         triangle_tau = [ [] for n in xrange(self.N) ]

--- a/pyed/SquareTriangles.py
+++ b/pyed/SquareTriangles.py
@@ -74,13 +74,13 @@ class SuqareTraingles(SquareTrianglesBase):
     # ------------------------------------------------------------------
     def __iter__(self):
 
-        for tidx in xrange(self.N):
+        for tidx in range(self.N):
             
             func, perm, perm_sign = self.triangle_list[tidx]
     
             index = []
             for n1, n2 in itertools.product(
-                    range(self.ntau), repeat=2):
+                    list(range(self.ntau)), repeat=2):
                 if func(n1, n2): index.append((n1, n2))
 
             index = np.array(index).T
@@ -112,8 +112,8 @@ class SquareTrianglesMesh(SquareTrianglesBase):
 
         """ for triqs three time greens functions """
 
-        triangle_idx = [ [] for n in xrange(self.N) ]
-        triangle_tau = [ [] for n in xrange(self.N) ]
+        triangle_idx = [ [] for n in range(self.N) ]
+        triangle_tau = [ [] for n in range(self.N) ]
 
         for idxs, taus in enumerate_tau2(self.g3_tau):
             
@@ -125,7 +125,7 @@ class SquareTrianglesMesh(SquareTrianglesBase):
                     triangle_tau[tidx] += [ taus ]
                     break
 
-        for tidx in xrange(self.N):
+        for tidx in range(self.N):
             func, perm, perm_sign = self.triangle_list[tidx]
 
             yield triangle_idx[tidx], triangle_tau[tidx], perm, perm_sign

--- a/pyed/TriqsExactDiagonalization.py
+++ b/pyed/TriqsExactDiagonalization.py
@@ -12,9 +12,9 @@ import numpy as np
 
 # ----------------------------------------------------------------------
 
-from pytriqs.gf import MeshImTime, MeshProduct, Idx
-from pytriqs.operators import dagger
-from pytriqs.utility import mpi
+from triqs.gf import MeshImTime, MeshProduct, Idx
+from triqs.operators import dagger
+from triqs.utility import mpi
 
 # ----------------------------------------------------------------------
 

--- a/pyed/TriqsExactDiagonalization.py
+++ b/pyed/TriqsExactDiagonalization.py
@@ -130,7 +130,7 @@ class TriqsExactDiagonalization(object):
         raw_tail = self.ed.get_high_frequency_tail_coeff_component(
             op1_mat, op2_mat, self.xi(g.mesh), Norder=tail.order_max)
 
-        for idx in xrange(tail.order_max):
+        for idx in range(tail.order_max):
             tail[idx+1] = raw_tail[idx]
 
     # ------------------------------------------------------------------

--- a/pyed/tests/test_G_tau_and_G_iw.py
+++ b/pyed/tests/test_G_tau_and_G_iw.py
@@ -11,13 +11,13 @@ import numpy as np
 
 # ----------------------------------------------------------------------
 
-from pytriqs.gf import Gf
-from pytriqs.gf import MeshImTime, MeshImFreq
+from triqs.gf import Gf
+from triqs.gf import MeshImTime, MeshImFreq
 
-from pytriqs.gf import GfImTime, GfImFreq
-from pytriqs.operators import c, c_dag
+from triqs.gf import GfImTime, GfImFreq
+from triqs.operators import c, c_dag
 
-from pytriqs.gf import inverse, iOmega_n, InverseFourier
+from triqs.gf import inverse, iOmega_n, InverseFourier
 
 # ----------------------------------------------------------------------
 
@@ -56,7 +56,7 @@ def test_cf_G_tau_and_G_iw_nonint(verbose=False):
     # ------------------------------------------------------------------
     # -- Compare gfs
 
-    from pytriqs.utility.comparison_tests import assert_gfs_are_close
+    from triqs.utility.comparison_tests import assert_gfs_are_close
     
     assert_gfs_are_close(G_tau, G_tau_ed)
     assert_gfs_are_close(G_iw, G_iw_ed)
@@ -65,7 +65,7 @@ def test_cf_G_tau_and_G_iw_nonint(verbose=False):
     # -- Plotting
     
     if verbose:
-        from pytriqs.plot.mpl_interface import oplot, plt
+        from triqs.plot.mpl_interface import oplot, plt
         subp = [3, 1, 1]
         plt.subplot(*subp); subp[-1] += 1
         oplot(G_tau.real)

--- a/pyed/tests/test_G_tau_and_G_iw.py
+++ b/pyed/tests/test_G_tau_and_G_iw.py
@@ -17,7 +17,7 @@ from triqs.gf import MeshImTime, MeshImFreq
 from triqs.gf import GfImTime, GfImFreq
 from triqs.operators import c, c_dag
 
-from triqs.gf import inverse, iOmega_n, InverseFourier
+from triqs.gf import inverse, iOmega_n, Fourier
 
 # ----------------------------------------------------------------------
 
@@ -45,7 +45,7 @@ def test_cf_G_tau_and_G_iw_nonint(verbose=False):
     G_iw = GfImFreq(beta=beta, statistic='Fermion', n_points=niw, target_shape=(1,1))
 
     G_iw << inverse( iOmega_n - eps )
-    G_tau << InverseFourier(G_iw)
+    G_tau << Fourier(G_iw)
 
     G_tau_ed = GfImTime(beta=beta, statistic='Fermion', n_points=ntau, target_shape=(1,1))
     G_iw_ed = GfImFreq(beta=beta, statistic='Fermion', n_points=niw, target_shape=(1,1))

--- a/pyed/tests/test_operator_utils.py
+++ b/pyed/tests/test_operator_utils.py
@@ -48,7 +48,7 @@ def test_gf_struct():
         c('do', 2),
         ]
 
-    print fundamental_operators
+    print(fundamental_operators)
     assert( fundamental_operators == fundamental_operators_ref )
 
 # ----------------------------------------------------------------------
@@ -73,7 +73,7 @@ def test_quadratic():
     h_loc = np.random.random((n, n))
     h_loc = 0.5 * (h_loc + h_loc.T)
 
-    fund_op = [ c(0, idx) for idx in xrange(n) ]
+    fund_op = [ c(0, idx) for idx in range(n) ]
     H_loc = get_quadratic_operator(h_loc, fund_op)
     h_loc_ref = quadratic_matrix_from_operator(H_loc, fund_op)
     
@@ -83,7 +83,7 @@ def test_quadratic():
 def test_quartic(verbose=False):
 
     if verbose:
-        print '--> test_quartic'
+        print('--> test_quartic')
         
     num_orbitals = 2
     num_spins = 2
@@ -92,13 +92,13 @@ def test_quartic(verbose=False):
 
     up, do = 0, 1
     spin_names = [up, do]
-    orb_names = range(num_orbitals)
+    orb_names = list(range(num_orbitals))
     
     U_ab, UPrime_ab = U_matrix_kanamori(n_orb=2, U_int=U, J_hund=J)
 
     if verbose:
-        print 'U_ab =\n', U_ab
-        print 'UPrime_ab =\n', UPrime_ab
+        print('U_ab =\n', U_ab)
+        print('UPrime_ab =\n', UPrime_ab)
 
     T_ab = np.array([
         [1., 1.],
@@ -119,8 +119,8 @@ def test_quartic(verbose=False):
     Ht_int = operator_single_particle_transform(H_int, T_ab_spin, op_imp)
 
     if verbose:
-        print 'H_int =', H_int
-        print 'Ht_int =', Ht_int
+        print('H_int =', H_int)
+        print('Ht_int =', Ht_int)
 
     from transform_kanamori import h_int_kanamori_transformed
 
@@ -129,7 +129,7 @@ def test_quartic(verbose=False):
         off_diag=True, map_operator_structure=None, H_dump=None)
 
     if verbose:
-        print 'Ht_int_ref =', Ht_int_ref
+        print('Ht_int_ref =', Ht_int_ref)
     
     assert( (Ht_int_ref - Ht_int).is_zero() )
 
@@ -137,7 +137,7 @@ def test_quartic(verbose=False):
 def test_single_particle_transform(verbose=False):
 
     if verbose:
-        print '--> test_single_particle_transform'
+        print('--> test_single_particle_transform')
         
     h_loc = np.array([
         [1.0, 0.0],
@@ -155,9 +155,9 @@ def test_single_particle_transform(verbose=False):
     np.testing.assert_array_almost_equal(h_loc, h_loc_ref)
 
     if verbose:
-        print 'h_loc =\n', h_loc
-        print 'h_loc_ref =\n', h_loc_ref
-        print 'H_loc =', H_loc
+        print('h_loc =\n', h_loc)
+        print('h_loc_ref =\n', h_loc_ref)
+        print('H_loc =', H_loc)
 
     T_ab = np.array([
         [1., 1.],
@@ -175,10 +175,10 @@ def test_single_particle_transform(verbose=False):
     Ht_loc_ref = c_dag(0, 0) * c(0, 1) + c_dag(0, 1) * c(0, 0)
 
     if verbose:
-        print 'ht_loc =\n', ht_loc
-        print 'ht_loc_ref =\n', ht_loc_ref
-        print 'Ht_loc =', Ht_loc
-        print 'Ht_loc_ref =', Ht_loc_ref
+        print('ht_loc =\n', ht_loc)
+        print('ht_loc_ref =\n', ht_loc_ref)
+        print('Ht_loc =', Ht_loc)
+        print('Ht_loc_ref =', Ht_loc_ref)
     
     assert( (Ht_loc - Ht_loc_ref).is_zero() )
 
@@ -199,10 +199,10 @@ def test_quartic_tensor_from_operator(verbose=False):
     np.testing.assert_array_almost_equal(U_ref, U_sym)
 
     if verbose:
-        print '-'*72
+        print('-'*72)
         import itertools
-        for idxs in itertools.product(range(N), repeat=4):
-            print idxs, U_ref[idxs] - U_sym[idxs], U[idxs], U_ref[idxs], U_sym[idxs]
+        for idxs in itertools.product(list(range(N)), repeat=4):
+            print(idxs, U_ref[idxs] - U_sym[idxs], U[idxs], U_ref[idxs], U_sym[idxs])
 
 # ----------------------------------------------------------------------
 if __name__ == '__main__':

--- a/pyed/tests/test_operator_utils.py
+++ b/pyed/tests/test_operator_utils.py
@@ -11,10 +11,10 @@ import numpy as np
 
 # ----------------------------------------------------------------------
 
-from pytriqs.operators import n, c, c_dag, Operator, dagger
+from triqs.operators import n, c, c_dag, Operator, dagger
 
-from pytriqs.operators.util.U_matrix import U_matrix_kanamori, U_matrix
-from pytriqs.operators.util.hamiltonians import h_int_kanamori
+from triqs.operators.util.U_matrix import U_matrix_kanamori, U_matrix
+from triqs.operators.util.hamiltonians import h_int_kanamori
 
 from transform_kanamori import h_int_kanamori_transformed
 

--- a/pyed/tests/test_sparse_matrix_fockstates.py
+++ b/pyed/tests/test_sparse_matrix_fockstates.py
@@ -12,7 +12,7 @@ import numpy as np
 
 # ----------------------------------------------------------------------
 
-from pytriqs.operators import c, c_dag
+from triqs.operators import c, c_dag
 
 # ----------------------------------------------------------------------
 

--- a/pyed/tests/test_two_particle_greens_function.py
+++ b/pyed/tests/test_two_particle_greens_function.py
@@ -12,10 +12,10 @@ import numpy as np
 
 #----------------------------------------------------------------------
 
-from pytriqs.gf import Gf, GfImTime
-from pytriqs.gf import MeshImTime, MeshProduct
+from triqs.gf import Gf, GfImTime
+from triqs.gf import MeshImTime, MeshProduct
 
-from pytriqs.operators import c, c_dag
+from triqs.operators import c, c_dag
 
 #----------------------------------------------------------------------
 

--- a/pyed/tests/transform_kanamori.py
+++ b/pyed/tests/transform_kanamori.py
@@ -9,8 +9,8 @@ Author: Gernot J. Kraberger (2016) """
 import numpy as np
 from itertools import product
 
-from pytriqs.operators.util import get_mkind
-from pytriqs.operators import c, c_dag, Operator, dagger
+from triqs.operators.util import get_mkind
+from triqs.operators import c, c_dag, Operator, dagger
 
 # ----------------------------------------------------------------------
 def h_int_kanamori_d(spin_names, orb_names, U, Uprime, J_hund,

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,2 @@
+from setuptools import setup
+setup(name="pyed", packages=["pyed"])


### PR DESCRIPTION
I have updated the entire code base to TRIQS 3 and Python 3, including the documentation.  However, the `plot.py` scripts for both benchmarks `hubbard_atom_two_bathsites` and `spinless` do not work.  Yet I don't see how they would have ever worked, so I don't think this is a regression from updating.
- The `benchmark/hubbard_atom_two_bathsites/plot.py` tries to plot the two-particle Green's function over “slice planes”, but the corresponding `calc.py` does not calculate the two-particle Green's function on different “slice planes”.
- The `benchmark/spinless/plot.py` tries to load two data files `data_ed.h5` and `spinless.ed.h5`, but only the former is created by the corresponding `calc.py`.

The `setup.py` that I have included is very minimalist and only contains the mandatory fields.  Luckily the `pyed` code already has the correct directory layout so the `setup.py` Just Works™.  In general this should also contain version, author, and license information but since I did not author this code, I did not feel comfortable filling this in.