### PR TITLE
fix: cleanup whitespace

### DIFF
--- a/benchmark/hubbard_atom_two_bathsites/calc.py
+++ b/benchmark/hubbard_atom_two_bathsites/calc.py
@@ -1,9 +1,8 @@
-  
 """ Test calculation for Hubbard atom with two bath sites.
 
 Author: Hugo U.R. Strand (2017) hugo.strand@gmail.com
 
- """ 
+ """
 
 # ----------------------------------------------------------------------
 
@@ -24,10 +23,10 @@ from pyed.TriqsExactDiagonalization import TriqsExactDiagonalization
 
 # ----------------------------------------------------------------------
 if __name__ == '__main__':
-    
+
     # ------------------------------------------------------------------
     # -- Hubbard atom with two bath sites, Hamiltonian
-    
+
     beta = 2.0
     V1 = 2.0
     V2 = 5.0
@@ -47,13 +46,13 @@ if __name__ == '__main__':
               c_dag(do,0)*c(do,1) + c_dag(do,1)*c(do,0) ) + \
         V2 * (c_dag(up,0)*c(up,2) + c_dag(up,2)*c(up,0) + \
               c_dag(do,0)*c(do,2) + c_dag(do,2)*c(do,0) )
-    
+
     # ------------------------------------------------------------------
     # -- Exact diagonalization
 
     fundamental_operators = [
         c(up,0), c(do,0), c(up,1), c(do,1), c(up,2), c(do,2)]
-    
+
     ed = TriqsExactDiagonalization(H, fundamental_operators, beta)
 
     # ------------------------------------------------------------------
@@ -66,13 +65,13 @@ if __name__ == '__main__':
     g_iwn = GfImFreq(name='$g$', beta=beta,
                      statistic='Fermion', n_points=10,
                      target_shape=(1,1))
-    
+
     ed.set_g2_tau(g_tau[0,0], c(up,0), c_dag(up,0))
     ed.set_g2_iwn(g_iwn[0,0], c(up,0), c_dag(up,0))
 
     # ------------------------------------------------------------------
     # -- Two particle Green's functions
-    
+
     ntau = 20
     imtime = MeshImTime(beta, 'Fermion', ntau)
     prodmesh = MeshProduct(imtime, imtime, imtime)
@@ -92,15 +91,15 @@ if __name__ == '__main__':
 
     # ------------------------------------------------------------------
     # -- Store to hdf5
-    
+
     with HDFArchive('data_ed.h5','w') as res:
-                
+
         res["G_tau"] = g_tau
         res["G_iw"] = g_iwn
-        
+
         res["G20_tau"] = g40_tau
         res["G2_tau"] = g4_tau
 
         res["G3pp_tau"] = g3pp_tau
-        
+
 # ----------------------------------------------------------------------

--- a/benchmark/hubbard_atom_two_bathsites/plot.py
+++ b/benchmark/hubbard_atom_two_bathsites/plot.py
@@ -17,7 +17,7 @@ from h5 import HDFArchive
 # ----------------------------------------------------------------------
 
 from pyed.CubeTetras import zero_outer_planes_and_equal_times
-            
+
 # ----------------------------------------------------------------------
 def hack_label_separation(ax, fontsize=6, pad=-2):
     for ticks in [ax.xaxis.get_major_ticks(),
@@ -36,15 +36,15 @@ def plot_2d_g(ax, g2_tau, **kwargs):
     #X, Y = np.meshgrid(x, x)
     t1, t2 = np.meshgrid(tau, tau)
     ax.plot_wireframe(t1, t2, data.real, **kwargs)
-    
+
 # ----------------------------------------------------------------------
 if __name__ == '__main__':
-    
+
     A = HDFArchive('data_ed.h5', 'r')
 
     # ------------------------------------------------------------------
     # -- Single-particle Green's function
-    
+
     g_tau = A['G_tau']
     tau = np.array([tau.value for tau in g_tau.mesh])
 
@@ -56,7 +56,7 @@ if __name__ == '__main__':
     plt.tight_layout()
     #oplot(g_tau)
     plt.savefig('figure_g_tau.pdf')
-    
+
     # ------------------------------------------------------------------
     # -- Two-particle Green's function at equal times
 
@@ -72,13 +72,13 @@ if __name__ == '__main__':
     ax.set_ylabel(r'$\tau_2$', labelpad=-8)
     #ax.set_zlabel(r'$G(\tau_1, \tau_2, \tau_3)$', labelpad=-8)
     ax.set_title(r'$G^{(4)}(\tau_1, \tau_2, 0^+)$', loc='left', fontdict=dict(fontsize=10))
- 
+
     #ax.set_zlim([-0.15, 0.15])
     #ax.set_zlim([-0.09, 0.09])
 
     hack_label_separation(ax, fontsize=6, pad=-2)
     plt.tight_layout()
-    plt.savefig('figure_g3pp_tau.pdf')    
+    plt.savefig('figure_g3pp_tau.pdf')
 
     # ------------------------------------------------------------------
     # -- Two-particle Green's function
@@ -91,7 +91,7 @@ if __name__ == '__main__':
 
     fig = plt.figure(figsize=(3.25*2, 2.5))
     subp = [1, 3, 1]
-    
+
     # -- All slice planes
     for i1, i2 in itertools.combinations(list(range(3)), 2):
 
@@ -102,8 +102,8 @@ if __name__ == '__main__':
         time_labels = [r'$\tau_1$', r'$\tau_2$', r'$\tau_3$']
         xlabel, ylabel = time_labels[i1], time_labels[i2]
         title = time_labels[list(set(range(3)).difference(set([i1, i2])))[0]] + r'$=\beta/%i$' % frac_cut
-        
-        
+
+
         ax = fig.add_subplot(*subp, projection='3d')
         subp[-1] += 1
 
@@ -117,7 +117,7 @@ if __name__ == '__main__':
         ax.set_ylabel(ylabel, labelpad=-8)
         #ax.set_zlabel(r'$G(\tau_1, \tau_2, \tau_3)$', labelpad=-8)
         ax.set_title(title, loc='left', fontdict=dict(fontsize=10))
- 
+
         #ax.set_zlim([-0.15, 0.15])
         ax.set_zlim([-0.09, 0.09])
 
@@ -128,5 +128,5 @@ if __name__ == '__main__':
     plt.savefig('figure_g2_tau.pdf')
 
     #plt.show()
-    
+
 # ----------------------------------------------------------------------

--- a/benchmark/spinless/calc.py
+++ b/benchmark/spinless/calc.py
@@ -1,11 +1,10 @@
-  
 """ Test calculation for Hubbard atom with two bath sites.
 
 Using parameters of cthyb benchmark "spinless" with hybridization of spins...
 
 Author: Hugo U.R. Strand (2017) hugo.strand@gmail.com
 
- """ 
+ """
 
 # ----------------------------------------------------------------------
 
@@ -27,10 +26,10 @@ from pyed.TriqsExactDiagonalization import TriqsExactDiagonalization
 
 # ----------------------------------------------------------------------
 if __name__ == '__main__':
-    
+
     # ------------------------------------------------------------------
     # -- Hubbard atom with two bath sites, Hamiltonian
-    
+
     beta = 10.0
     V1 = 1.0
     V2 = 1.0
@@ -56,13 +55,13 @@ if __name__ == '__main__':
         V2 * (c_dag(up,0)*c(up,2) + c_dag(up,2)*c(up,0) + \
               c_dag(do,0)*c(do,2) + c_dag(do,2)*c(do,0) ) + \
         -t * (hopA + hopB + hopC)
-    
+
     # ------------------------------------------------------------------
     # -- Exact diagonalization
 
     fundamental_operators = [
         c(up,0), c(do,0), c(up,1), c(do,1), c(up,2), c(do,2)]
-    
+
     ed = TriqsExactDiagonalization(H, fundamental_operators, beta)
 
     # ------------------------------------------------------------------
@@ -78,8 +77,8 @@ if __name__ == '__main__':
 
     # ------------------------------------------------------------------
     # -- Store to hdf5
-    
+
     with HDFArchive('data_ed.h5','w') as res:
         res['tot'] = g_tau
-        
+
 # ----------------------------------------------------------------------

--- a/benchmark/spinless/plot.py
+++ b/benchmark/spinless/plot.py
@@ -21,7 +21,6 @@ if __name__ == '__main__':
 
     with HDFArchive('spinless.ed.h5', 'r') as res:
         oplotr(res['tot'], name='ed')
-        
+
     plt.savefig('figure_ed_vs_pyed.pdf')
     plt.show()
-        

--- a/pyed/CubeTetras.py
+++ b/pyed/CubeTetras.py
@@ -1,5 +1,4 @@
-
-""" 
+"""
 Helper routines for the equal time imaginary time cube and
 its sub tetrahedrons.
 
@@ -21,7 +20,7 @@ def zero_outer_planes_and_equal_times(g4_tau):
 
     from triqs.gf import Idx
     beta = g4_tau.mesh.components[0].beta
-    
+
     for idxs, (t1, t2, t3) in enumerate_tau3(g4_tau):
         if t1 == t2 or t2 == t3 or t1 == t3 or \
            t1 == 0 or t1 == beta or \
@@ -33,7 +32,7 @@ def zero_outer_planes_and_equal_times(g4_tau):
 def enumerate_tau3(g4_tau, make_real=True, beta=None):
 
     from triqs.gf import MeshImTime, MeshProduct
-    
+
     assert( type(g4_tau.mesh) == MeshProduct )
 
     for mesh in g4_tau.mesh.components:
@@ -46,13 +45,13 @@ def enumerate_tau3(g4_tau, make_real=True, beta=None):
             yield (i1, i2, i3), (t1.real, t2.real, t3.real)
         else:
             yield (i1, i2, i3), (t1, t2, t3)
-            
+
 # ----------------------------------------------------------------------
 class CubeTetrasBase(object):
 
     """ Base class with definition of the equal time tetrahedrons
     in three fermionic imaginary times. """
-    
+
     def get_tetra_list(self):
 
         tetra_list = [
@@ -63,17 +62,17 @@ class CubeTetrasBase(object):
             (lambda x,y,z : x >= z and z >= y, [0, 2, 1], -1),
             (lambda x,y,z : z >= x and x >= y, [2, 0, 1], +1),
             ]
-        
+
         return tetra_list
 
 # ----------------------------------------------------------------------
 class CubeTetras(CubeTetrasBase):
 
     """ Helper class for two-particle Green's function.
-    
+
     Looping over all tetrahedrons in the imaginary time cube.
     \tau_1, \tau_2, \tau_3 \in [0, \beta) """
-    
+
     # ------------------------------------------------------------------
     def __init__(self, tau):
 
@@ -85,21 +84,21 @@ class CubeTetras(CubeTetrasBase):
     def __iter__(self):
 
         for tidx in range(6):
-            
+
             func, perm, perm_sign = self.tetra_list[tidx]
-    
+
             index = []
             for n1, n2, n3 in itertools.product(
                     list(range(self.ntau)), repeat=3):
                 if func(n1, n2, n3): index.append((n1, n2, n3))
 
             index = np.array(index).T
-            
+
             i1, i2, i3 = index
             t1, t2, t3 = self.tau[i1], self.tau[i2], self.tau[i3]
 
             taus = np.vstack([t1, t2, t3])
-        
+
             yield list(index), taus, perm, perm_sign
 
 # ----------------------------------------------------------------------
@@ -107,16 +106,16 @@ class CubeTetrasMesh(CubeTetrasBase):
 
     """ Helper class for Triqs two-particle Green's function
     in imaginary time.
-    
+
     Looping over all tetrahedrons in the imaginary time cube.
     \tau_1, \tau_2, \tau_3 \in [0, \beta) """
-    
+
     # ------------------------------------------------------------------
     def __init__(self, g4_tau):
 
         self.g4_tau = g4_tau
         self.tetra_list = self.get_tetra_list()
-        
+
     # ------------------------------------------------------------------
     def __iter__(self):
 
@@ -126,7 +125,7 @@ class CubeTetrasMesh(CubeTetrasBase):
         tetra_tau = [ [] for n in range(6) ]
 
         for idxs, taus in enumerate_tau3(self.g4_tau):
-            
+
             for tidx, tetra in enumerate(self.tetra_list):
                 func, perm, perm_sign = tetra
 
@@ -139,5 +138,5 @@ class CubeTetrasMesh(CubeTetrasBase):
             func, perm, perm_sign = self.tetra_list[tidx]
 
             yield tetra_idx[tidx], tetra_tau[tidx], perm, perm_sign
-            
+
 # ----------------------------------------------------------------------

--- a/pyed/GfUtils.py
+++ b/pyed/GfUtils.py
@@ -1,5 +1,4 @@
-
-""" 
+"""
 Triqs Green's function utilities
 
 Author: Hugo U. R. Strand (2018), hugo.strand@gmail.com
@@ -19,7 +18,7 @@ def g2_single_particle_transform(g2, T):
     g2t.from_L_G_R(T, g2, T.H)
 
     return g2t
-    
+
 # ----------------------------------------------------------------------
 def g4_single_particle_transform(g4, T):
 
@@ -31,4 +30,3 @@ def g4_single_particle_transform(g4, T):
         T, T.conjugate(), T, T.conjugate(), g4.data)
 
     return g4t
-    

--- a/pyed/ParameterCollection.py
+++ b/pyed/ParameterCollection.py
@@ -31,7 +31,7 @@ class ParameterCollection(object):
         return list(self.__dict__.items())
 
     def keys(self):
-   	return list(self.__dict__.keys())
+        return list(self.__dict__.keys())
 
     def dict(self):
         return self.__dict__
@@ -43,9 +43,9 @@ class ParameterCollection(object):
         return self.__dict__
 
     def _clean_bools(self):
-        """ Fix for bug in Triqs that cast bool to numpy.bool_ 
+        """ Fix for bug in Triqs that cast bool to numpy.bool_
         here we cast all numpy.bools_ to plain python bools """
-        
+
         for key, value in list(self.items()):
             if type(value) == np.bool_:
                 self.dict()[key] = bool(value)
@@ -58,9 +58,9 @@ class ParameterCollection(object):
         d = self.dict()[dict_key]
         d_fix = {}
         for key, value in list(d.items()):
-            d_fix[eval(key)] = value            
+            d_fix[eval(key)] = value
         self.dict()[dict_key] = d_fix
-    
+
     def grab_attribs(self, obj, keys):
         for key in keys:
             val = getattr(obj, key)
@@ -90,7 +90,7 @@ class ParameterCollection(object):
                 max_lines = 10
                 if len(str_value_lines) > max_lines:
                     str_value = '\n'.join(str_value_lines[:max_lines] + ['...'])
-                
+
                 out += ''.join([key, ' = ', str_value]) + '\n'
         return out
 
@@ -107,5 +107,5 @@ class ParameterCollection(object):
 
 # -- Register ParameterCollection in Triqs formats
 
-from h5.formats import register_class 
+from h5.formats import register_class
 register_class(ParameterCollection)

--- a/pyed/SparseExactDiagonalization.py
+++ b/pyed/SparseExactDiagonalization.py
@@ -1,4 +1,3 @@
-
 """
 General routines for exact diagonalization using sparse matrices
 
@@ -24,7 +23,7 @@ from .CubeTetras import CubeTetras
 # ----------------------------------------------------------------------
 class SparseExactDiagonalization(object):
 
-    """ Exact diagonalization and one- and two- particle Green's 
+    """ Exact diagonalization and one- and two- particle Green's
     function calculator. """
 
     # ------------------------------------------------------------------
@@ -34,20 +33,20 @@ class SparseExactDiagonalization(object):
 
         self.v0 = v0
         self.tol = tol
-        
+
         self.nstates = nstates
         self.hermitian = hermitian
-        
+
         self.H = H
         self.beta = beta
 
         self._diagonalize_hamiltonian()
         self._calculate_partition_function()
         self._calculate_density_matrix()
-        
+
     # ------------------------------------------------------------------
     def _diagonalize_hamiltonian(self):
-       
+
         if self.nstates is None:
             if self.hermitian:
                 self.E, self.U = np.linalg.eigh(self.H.todense())
@@ -64,7 +63,7 @@ class SparseExactDiagonalization(object):
                 self.E, self.U = eigs_sparse(
                     self.H, k=self.nstates, which='SR',
                     v0=self.v0, tol=self.tol)
-            
+
         self.U = np.mat(self.U)
         self.E0 = np.min(self.E)
         self.E = self.E - self.E0
@@ -90,7 +89,7 @@ class SparseExactDiagonalization(object):
             dop_vec.append(dop)
 
         return dop_vec
-        
+
     # ------------------------------------------------------------------
     def get_expectation_value_sparse(self, operator):
 
@@ -103,11 +102,11 @@ class SparseExactDiagonalization(object):
         exp_val /= self.Z
 
         return exp_val
-    
+
     # ------------------------------------------------------------------
     def get_expectation_value_dense(self, operator):
 
-        if not hasattr(self, 'rho'): self._calculate_density_matrix()            
+        if not hasattr(self, 'rho'): self._calculate_density_matrix()
         return np.sum(np.diag(operator * self.rho))
 
     # ------------------------------------------------------------------
@@ -117,7 +116,7 @@ class SparseExactDiagonalization(object):
             return self.get_expectation_value_dense(operator)
         else:
             return self.get_expectation_value_sparse(operator)
-    
+
     # ------------------------------------------------------------------
     def get_free_energy(self):
 
@@ -128,10 +127,10 @@ class SparseExactDiagonalization(object):
 
         Z = e^{-\beta E_0} x \sum_n e^{-\beta (E_n - E_0)} = e^{-beta E_0} Z'
         \Omega = -1/\beta ( \ln Z' - \beta E_0 ) """
-        
+
         Omega = -1./self.beta * (np.log(self.Z) - self.beta * self.E0)
         return Omega
-    
+
     # ------------------------------------------------------------------
     def get_partition_function(self):
         return self.Z
@@ -151,13 +150,13 @@ class SparseExactDiagonalization(object):
     # ------------------------------------------------------------------
     def get_ground_state_energy(self):
         return self.E0
-    
+
     # ------------------------------------------------------------------
     def get_g2_dissconnected_tau_tetra(self, tau, tau_g, g):
 
         g = np.squeeze(g) # fix for now throwing orb idx
         g = g.real
-        
+
         N = len(tau)
         G4 = np.zeros((N, N, N), dtype=np.complex)
 
@@ -181,7 +180,7 @@ class SparseExactDiagonalization(object):
 
         g = np.squeeze(g) # fix for now throwing orb idx
         g = g.real
-        
+
         N = len(tau)
         G4 = np.zeros((N, N, N), dtype=np.complex)
 
@@ -195,12 +194,12 @@ class SparseExactDiagonalization(object):
 
         t1, t2, t3 = np.meshgrid(tau, tau, tau, indexing='ij')
         G4 = gint(t1-t2)*gint(t3) - gint(t1)*gint(t3-t2)
-            
+
         return G4
-    
+
     # ------------------------------------------------------------------
     def get_g2_tau(self, tau, ops):
-        
+
         N = len(tau)
         G4 = np.zeros((N, N, N), dtype=np.complex)
         ops = np.array(ops)
@@ -209,16 +208,16 @@ class SparseExactDiagonalization(object):
             idx, taus, perm, perm_sign = tetra
 
             print('Tetra:', tidx)
-            
+
             # do not permute the last operator
             ops_perm = ops[perm + [3]]
             taus_perm = taus[perm] # permute the times
-            
+
             G4[idx] = self.get_timeordered_three_tau_greens_function(
                 taus_perm, ops_perm) * perm_sign
-            
+
         return G4
-    
+
     # ------------------------------------------------------------------
     def get_timeordered_two_tau_greens_function(self, taus, ops):
 
@@ -227,8 +226,8 @@ class SparseExactDiagonalization(object):
         ops = [O1, O2, O3]
 
         Returns:
-        G^{(4)}(t1, t2) = -1/Z < O1(t1) O2(t2) O3(0) > 
- 
+        G^{(4)}(t1, t2) = -1/Z < O1(t1) O2(t2) O3(0) >
+
         """
 
         Nop = 3
@@ -256,7 +255,7 @@ class SparseExactDiagonalization(object):
 
         G = np.einsum('ta,tb,tc,ab,bc,ca->t', et_a, et_b, et_c, op1, op2, op3)
 
-        G /= self.Z        
+        G /= self.Z
         return G
 
     # ------------------------------------------------------------------
@@ -267,8 +266,8 @@ class SparseExactDiagonalization(object):
         ops = [O1, O2, O3, O4]
 
         Returns:
-        G^{(4)}(t1, t2, t3) = -1/Z < O1(t1) O2(t2) O3(t3) O4(0) > 
- 
+        G^{(4)}(t1, t2, t3) = -1/Z < O1(t1) O2(t2) O3(t3) O4(0) >
+
         """
 
         assert( taus.shape[0] == 3 )
@@ -305,7 +304,7 @@ class SparseExactDiagonalization(object):
                 'ta,tb,tc,td,ab,bc,cd,da->t',
                 et_a, et_b, et_c, et_d, op1, op2, op3, op4)
 
-        G /= self.Z        
+        G /= self.Z
         return G
 
     # ------------------------------------------------------------------
@@ -319,18 +318,18 @@ class SparseExactDiagonalization(object):
         G = np.zeros((len(tau)), dtype=np.complex)
 
         op1_eig, op2_eig = self._operators_to_eigenbasis([op1, op2])
-        
+
         et_p = np.exp((-self.beta + tau[:,None])*self.E[None,:])
         et_m = np.exp(-tau[:,None]*self.E[None,:])
-        
+
         G = -np.einsum('tn,tm,nm,mn->t', et_p, et_m, op1_eig, op2_eig)
 
-        G /= self.Z        
+        G /= self.Z
         return G
 
     # ------------------------------------------------------------------
     def get_frequency_greens_function_component(self, iwn, op1, op2, xi):
-        
+
         r"""
         Returns:
         G^{(2)}(i\omega_n) = -1/Z < O_1(i\omega_n) O_2(-i\omega_n) >
@@ -354,18 +353,18 @@ class SparseExactDiagonalization(object):
         G = np.einsum('nm,mn,nm,znm->z', op1_eig, op2_eig, M, freq)
         G /= self.Z
 
-        return G        
-    
+        return G
+
     # ------------------------------------------------------------------
     def get_high_frequency_tail_coeff_component(
             self, op1, op2, xi, Norder=3):
-        
-        r""" The high frequency tail corrections can be derived 
+
+        r""" The high frequency tail corrections can be derived
         directly from the imaginary time expression for the Green's function
-        
+
         G(t) = -1/Z Tr[e^{-\beta H} e^{tH} b e^{-tH} b^+]
 
-        and the observation that the high frequency components of the 
+        and the observation that the high frequency components of the
         Matsubara Green's function G(i\omega_n) can be obtained by partial
         integration in
 
@@ -383,39 +382,39 @@ class SparseExactDiagonalization(object):
 
         Using this the high frequency coefficients c_k takes the form
 
-        c_k = (-1)^(k-1) (\xi G^{(k-1)}(\beta^-) - G^{(k-1)}(0^+)) 
+        c_k = (-1)^(k-1) (\xi G^{(k-1)}(\beta^-) - G^{(k-1)}(0^+))
             = (-1)^k < [ [[ H , b ]]^{(k-1)} , b^+ ]_{-\xi} >
 
         """
 
         def xi_commutator(A, B, xi):
             return A * B - xi * B * A
-            
+
         def commutator(A, B):
             return A * B - B * A
 
         H = self.H
-        
+
         Gc = np.zeros((Norder), dtype=np.complex)
         ba, bc = op1, op2
 
         Hba = ba
         for order in range(Norder):
-            tail_op = xi_commutator(Hba, bc, xi)                
+            tail_op = xi_commutator(Hba, bc, xi)
             Gc[order] = (-1.)**(order) * \
                         self.get_expectation_value(tail_op)
             Hba = commutator(H, Hba)
-                
-        return Gc      
+
+        return Gc
 
     # ------------------------------------------------------------------
     def get_high_frequency_tail(self, iwn, Gc, start_order=-1):
 
-        """ from the high frequency coefficients Gc calculate the 
+        """ from the high frequency coefficients Gc calculate the
         Matsubara Green's function tail
 
         G(i\omega_n) = \sum_k Gc[k] / (i\omega_n)^k """
-        
+
         Nop = Gc.shape[-1]
         Nw = len(iwn)
         G = np.zeros((Nw, Nop, Nop), dtype=np.complex)
@@ -424,7 +423,7 @@ class SparseExactDiagonalization(object):
             G[iwn_idx, :, :] += \
                 iwn[iwn_idx, None, None]**(-idx+start_order) * gc[None, :, :]
 
-        return G            
+        return G
 
     # ------------------------------------------------------------------
 

--- a/pyed/SparseMatrixFockStates.py
+++ b/pyed/SparseMatrixFockStates.py
@@ -1,4 +1,3 @@
-
 """
 Sparse matrix representation of fermionic creation
 and annihilation operators for a finite Fock space.
@@ -15,10 +14,10 @@ from scipy import sparse
 # ----------------------------------------------------------------------
 class SparseMatrixRepresentation(object):
 
-    """ Generator for sparse matrix representations of 
-    Triqs operator expressions, given a set of fundamental 
+    """ Generator for sparse matrix representations of
+    Triqs operator expressions, given a set of fundamental
     creation operators. """
-    
+
     # ------------------------------------------------------------------
     def __init__(self, fundamental_operators):
 
@@ -43,7 +42,7 @@ class SparseMatrixRepresentation(object):
 
         assert len(operator_labels_set) == len(self.operator_labels), \
             "ERROR: Repeated operators in fundamental_operators!"
-        
+
         self.operator_labels = [
             (dag, list(idx)) for dag, idx in self.operator_labels ]
 
@@ -56,25 +55,25 @@ class SparseMatrixRepresentation(object):
 
         """ Convert a general Triqs operator expression to a sparse
         matrix representation. """
-        
+
         matrix_rep = 0.0 * self.sparse_operators.I
-    
+
         for term, coef in triqs_operator_expression:
 
             product = coef * self.sparse_operators.I
-            
+
             for fact in term:
 
                 dagger, idx = fact
                 oidx = self.operator_labels.index((False, idx))
 
                 op = self.sparse_operators.c_dag[oidx]
-                if not dagger: op = op.getH()                
+                if not dagger: op = op.getH()
 
                 product = product * op
 
             matrix_rep = matrix_rep + product
-            
+
         return matrix_rep
 
     # ------------------------------------------------------------------
@@ -84,20 +83,20 @@ class SparseMatrixRepresentation(object):
 
         from sympy.matrices import SparseMatrix
         from sympy.simplify.simplify import nsimplify
-        
+
         d = dict([ ((i, j), nsimplify(val)) \
                    for (i, j), val in Hsp.todok().items() ])
-        
+
         H = SparseMatrix(Hsp.shape[0], Hsp.shape[1], d)
 
         return H
-    
+
 # ----------------------------------------------------------------------
 class SparseMatrixCreationOperators:
 
-    """ Generator of sparse matrix representation of fermionic 
+    """ Generator of sparse matrix representation of fermionic
     creation operators, for finite number of fermions. """
-    
+
     # ------------------------------------------------------------------
     def __init__(self, nfermions):
 
@@ -111,7 +110,7 @@ class SparseMatrixCreationOperators:
 
         self.I = sparse.eye(
             self.nstates, self.nstates, dtype=np.float64, format='csr')
-            
+
     # ------------------------------------------------------------------
     def _build_creation_operator(self, orbidx):
         nstates = self.nstates
@@ -131,7 +130,7 @@ class SparseMatrixCreationOperators:
 
         # -- collect sign
         sign = 1 - 2*np.array(
-            np.mod(np.sum(rightstates[:, 1:], axis=1), 2), 
+            np.mod(np.sum(rightstates[:, 1:], axis=1), 2),
             dtype=np.float64)
 
         # -- Transform back to uint16
@@ -152,4 +151,3 @@ class SparseMatrixCreationOperators:
         return cdagger
 
 # ----------------------------------------------------------------------
-    

--- a/pyed/SquareTriangles.py
+++ b/pyed/SquareTriangles.py
@@ -1,5 +1,4 @@
-
-""" 
+"""
 Helper routines for the equal time imaginary time square and
 its sub triangles.
 
@@ -15,7 +14,7 @@ import numpy as np
 def zero_outer_planes_and_equal_times(g3_tau):
 
     beta = g3_tau.mesh.components[0].beta
-    
+
     for idxs, (t1, t2) in enumerate_tau2(g3_tau):
         if t1 == t2 or \
            t1 == 0 or t1 == beta or \
@@ -26,7 +25,7 @@ def zero_outer_planes_and_equal_times(g3_tau):
 def enumerate_tau2(g3_tau, make_real=True, beta=None):
 
     from triqs.gf import MeshImTime, MeshProduct
-    
+
     assert( type(g3_tau.mesh) == MeshProduct )
 
     for mesh in g3_tau.mesh.components:
@@ -39,30 +38,30 @@ def enumerate_tau2(g3_tau, make_real=True, beta=None):
             yield (i1, i2), (t1.real, t2.real)
         else:
             yield (i1, i2), (t1, t2)
-            
+
 # ----------------------------------------------------------------------
 class SquareTrianglesBase(object):
 
     """ Base class with definition of the equal time tetrahedrons
     in three fermionic imaginary times. """
-    
+
     def get_triangle_list(self):
 
         triangle_list = [
             (lambda x,y : x >= y, [0, 1], +1),
             (lambda x,y : x <  y, [1, 0], -1),
             ]
-        
+
         return triangle_list
 
 # ----------------------------------------------------------------------
 class SuqareTraingles(SquareTrianglesBase):
 
     """ Helper class for two imaginary time Green's functions.
-    
+
     Looping of the triangles on the imaginary time square.
     \tau_1, \tau_2 \in [0, \beta) """
-    
+
     # ------------------------------------------------------------------
     def __init__(self, tau):
 
@@ -75,38 +74,38 @@ class SuqareTraingles(SquareTrianglesBase):
     def __iter__(self):
 
         for tidx in range(self.N):
-            
+
             func, perm, perm_sign = self.triangle_list[tidx]
-    
+
             index = []
             for n1, n2 in itertools.product(
                     list(range(self.ntau)), repeat=2):
                 if func(n1, n2): index.append((n1, n2))
 
             index = np.array(index).T
-            
+
             i1, i2 = index
             t1, t2 = self.tau[i1], self.tau[i2]
 
             taus = np.vstack([t1, t2])
-        
+
             yield list(index), taus, perm, perm_sign
 
 # ----------------------------------------------------------------------
 class SquareTrianglesMesh(SquareTrianglesBase):
 
     """ Helper class for Triqs three imaginary time Green's functions.
-    
+
     Looping of the triangles on the imaginary time square.
     \tau_1, \tau_2 \in [0, \beta) """
-    
+
     # ------------------------------------------------------------------
     def __init__(self, g3_tau):
 
         self.g3_tau = g3_tau
         self.triangle_list = self.get_triangle_list()
         self.N = len(self.triangle_list)
-        
+
     # ------------------------------------------------------------------
     def __iter__(self):
 
@@ -116,7 +115,7 @@ class SquareTrianglesMesh(SquareTrianglesBase):
         triangle_tau = [ [] for n in range(self.N) ]
 
         for idxs, taus in enumerate_tau2(self.g3_tau):
-            
+
             for tidx, triangle in enumerate(self.triangle_list):
                 func, perm, perm_sign = triangle
 
@@ -129,5 +128,5 @@ class SquareTrianglesMesh(SquareTrianglesBase):
             func, perm, perm_sign = self.triangle_list[tidx]
 
             yield triangle_idx[tidx], triangle_tau[tidx], perm, perm_sign
-            
+
 # ----------------------------------------------------------------------

--- a/pyed/TriqsExactDiagonalization.py
+++ b/pyed/TriqsExactDiagonalization.py
@@ -1,5 +1,4 @@
-
-""" 
+"""
 Exact diagonalization and single- and two-particle Green's function calculator for Triqs operator expressions.
 
 Author: Hugo U. R. Strand (2017), hugo.strand@gmail.com
@@ -33,14 +32,14 @@ def mpi_op_comb(op_list, repeat=2):
 
 # ----------------------------------------------------------------------
 def mpi_all_reduce_g(g):
-    
+
     g << mpi.all_reduce(mpi.world, g, lambda x, y : x + y)
 
     return g
 
 # ----------------------------------------------------------------------
 class TriqsExactDiagonalization(object):
-    
+
     """ Exact diagonalization for Triqs operator expressions. """
 
     # ------------------------------------------------------------------
@@ -64,24 +63,24 @@ class TriqsExactDiagonalization(object):
         return self.ed.get_density_matrix()
     def get_ground_state_energy(self):
         return self.ed.get_ground_state_energy()
-        
+
     # ------------------------------------------------------------------
     def set_g2_tau(self, g_tau, op1, op2):
 
         assert( type(g_tau.mesh) == MeshImTime )
         assert( self.beta == g_tau.mesh.beta )
         assert( g_tau.target_shape == () )
-    
+
         op1_mat = self.rep.sparse_matrix(op1)
-        op2_mat = self.rep.sparse_matrix(op2)        
+        op2_mat = self.rep.sparse_matrix(op2)
 
         tau = np.array([tau.value for tau in g_tau.mesh])
- 
+
         g_tau.data[:] = self.ed.get_tau_greens_function_component(
                 tau, op1_mat, op2_mat)
 
         #self.set_tail(g_tau, op1_mat, op2_mat)
-        
+
     # ------------------------------------------------------------------
     def set_g2_tau_matrix(self, g_tau, op_list):
 
@@ -99,12 +98,12 @@ class TriqsExactDiagonalization(object):
 
         assert( self.beta == g_iwn.mesh.beta )
         assert( g_iwn.target_shape == () )
-    
+
         op1_mat = self.rep.sparse_matrix(op1)
-        op2_mat = self.rep.sparse_matrix(op2)        
+        op2_mat = self.rep.sparse_matrix(op2)
 
         iwn = np.array([iwn.value for iwn in g_iwn.mesh])
-        
+
         g_iwn.data[:] = self.ed.get_frequency_greens_function_component(
                 iwn, op1_mat, op2_mat, self.xi(g_iwn.mesh))
 
@@ -114,14 +113,14 @@ class TriqsExactDiagonalization(object):
     def set_g2_iwn_matrix(self, g_iwn, op_list):
 
         assert( g_iwn.target_shape == tuple([len(op_list)]*2) )
-        
+
         for (i1, o1), (i2, o2) in mpi_op_comb(op_list, repeat=2):
             self.set_g2_iwn(g_iwn[i1, i2], o1, dagger(o2))
 
         g_iw = mpi_all_reduce_g(g_iwn)
-        
+
         return g_iwn
-        
+
     # ------------------------------------------------------------------
     def set_tail(self, g, op1_mat, op2_mat):
 
@@ -141,7 +140,7 @@ class TriqsExactDiagonalization(object):
 
     # ------------------------------------------------------------------
     def set_g3_tau(self, g3_tau, op1, op2, op3):
-        
+
         assert( g3_tau.target_shape == () )
 
         ops = [op1, op2, op3]
@@ -171,12 +170,12 @@ class TriqsExactDiagonalization(object):
             n, t = np.divmod(t, beta)
             s = 2.*(n % 2) - 1.
             return s * g(t)
-        
+
         for t1, t2, t3 in g40_tau.mesh:
 
             t12 = t1 - t2
             t32 = t3 - t2
-            
+
             #g40_tau[t1, t2, t3] = g_tau(t1-t2) * g_tau(t3.value) - g_tau(t1.value) * g_tau(t3-t2)
             g40_tau[t1, t2, t3] = val(g_tau, t12) * val(g_tau, t3) - val(g_tau, t1) *  val(g_tau, t32)
 
@@ -193,14 +192,14 @@ class TriqsExactDiagonalization(object):
             n, t = np.divmod(t, beta)
             s = 2.*(n % 2) - 1.
             return s * g(t)
-        
+
         for t1, t2, t3 in g40_tau.mesh:
             g40_tau[t1, t2, t3] *= 0.
             #g40_tau[t1, t2, t3] += np.einsum('ba,dc->abcd', g_tau(t1-t2), g_tau(t3.value))
             #g40_tau[t1, t2, t3] -= np.einsum('da,bc->abcd', g_tau(t1.value), g_tau(t3-t2))
             g40_tau[t1, t2, t3] += np.einsum('ba,dc->abcd', val(g_tau, t1-t2), val(g_tau, t3))
             g40_tau[t1, t2, t3] -= np.einsum('da,bc->abcd', val(g_tau, t1), val(g_tau, t3-t2))
-    
+
     # ------------------------------------------------------------------
     def set_g4_tau(self, g4_tau, op1, op2, op3, op4):
 
@@ -222,7 +221,7 @@ class TriqsExactDiagonalization(object):
 
     # ------------------------------------------------------------------
     def set_g4_tau_matrix(self, g4_tau, op_list):
-        
+
         assert( g4_tau.target_shape == tuple([len(op_list)]*4) )
 
         for (i1, o1), (i2, o2), (i3, o3), (i4, o4) in \
@@ -231,7 +230,7 @@ class TriqsExactDiagonalization(object):
             self.set_g4_tau(g4_tau[i1, i2, i3, i4], o1, dagger(o2), o3, dagger(o4))
 
         g4_tau = mpi_all_reduce_g(g4_tau)
-        
+
         return g4_tau
-   
+
 # ----------------------------------------------------------------------

--- a/pyed/tests/test_G_tau_and_G_iw.py
+++ b/pyed/tests/test_G_tau_and_G_iw.py
@@ -1,9 +1,8 @@
-  
 """ Test calculation for Hubbard atom with two bath sites.
 
 Author: Hugo U.R. Strand (2017) hugo.strand@gmail.com
 
- """ 
+ """
 
 # ----------------------------------------------------------------------
 
@@ -31,7 +30,7 @@ def test_cf_G_tau_and_G_iw_nonint(verbose=False):
 
     niw = 64
     ntau = 2 * niw + 1
-    
+
     H = eps * c_dag(0,0) * c(0,0)
 
     fundamental_operators = [c(0,0)]
@@ -57,13 +56,13 @@ def test_cf_G_tau_and_G_iw_nonint(verbose=False):
     # -- Compare gfs
 
     from triqs.utility.comparison_tests import assert_gfs_are_close
-    
+
     assert_gfs_are_close(G_tau, G_tau_ed)
     assert_gfs_are_close(G_iw, G_iw_ed)
-    
+
     # ------------------------------------------------------------------
     # -- Plotting
-    
+
     if verbose:
         from triqs.plot.mpl_interface import oplot, plt
         subp = [3, 1, 1]
@@ -75,14 +74,14 @@ def test_cf_G_tau_and_G_iw_nonint(verbose=False):
         diff = G_tau - G_tau_ed
         oplot(diff.real)
         oplot(diff.imag)
-        
+
         plt.subplot(*subp); subp[-1] += 1
         oplot(G_iw)
         oplot(G_iw_ed)
-        
+
         plt.show()
 
 # ----------------------------------------------------------------------
 if __name__ == '__main__':
-    
+
     test_cf_G_tau_and_G_iw_nonint(verbose=True)

--- a/pyed/tests/test_operator_utils.py
+++ b/pyed/tests/test_operator_utils.py
@@ -1,9 +1,8 @@
-  
 """ Tests for OperatorUtils
 
 Author: Hugo U.R. Strand (2017) hugo.strand@gmail.com
 
- """ 
+ """
 
 # ----------------------------------------------------------------------
 
@@ -36,15 +35,15 @@ def test_gf_struct():
     orb_idxs = [0, 1, 2]
     spin_idxs = ['up', 'do']
     gf_struct = [ [spin_idx, orb_idxs] for spin_idx in spin_idxs ]
-    
+
     fundamental_operators = fundamental_operators_from_gf_struct(gf_struct)
 
     fundamental_operators_ref = [
-        c('up', 0), 
-        c('up', 1), 
-        c('up', 2), 
-        c('do', 0), 
-        c('do', 1), 
+        c('up', 0),
+        c('up', 1),
+        c('up', 2),
+        c('do', 0),
+        c('do', 1),
         c('do', 2),
         ]
 
@@ -69,14 +68,14 @@ def test_fundamental():
 def test_quadratic():
 
     n = 10
-    
+
     h_loc = np.random.random((n, n))
     h_loc = 0.5 * (h_loc + h_loc.T)
 
     fund_op = [ c(0, idx) for idx in range(n) ]
     H_loc = get_quadratic_operator(h_loc, fund_op)
     h_loc_ref = quadratic_matrix_from_operator(H_loc, fund_op)
-    
+
     np.testing.assert_array_almost_equal(h_loc, h_loc_ref)
 
 # ----------------------------------------------------------------------
@@ -84,7 +83,7 @@ def test_quartic(verbose=False):
 
     if verbose:
         print('--> test_quartic')
-        
+
     num_orbitals = 2
     num_spins = 2
 
@@ -93,7 +92,7 @@ def test_quartic(verbose=False):
     up, do = 0, 1
     spin_names = [up, do]
     orb_names = list(range(num_orbitals))
-    
+
     U_ab, UPrime_ab = U_matrix_kanamori(n_orb=2, U_int=U, J_hund=J)
 
     if verbose:
@@ -107,10 +106,10 @@ def test_quartic(verbose=False):
 
     # -- Check hermitian
     np.testing.assert_array_almost_equal(np.mat(T_ab) * np.mat(T_ab).H, np.eye(2))
-    
+
     I = np.eye(num_spins)
     T_ab_spin = np.kron(T_ab, I)
-    
+
     H_int = h_int_kanamori(
         spin_names, orb_names, U_ab, UPrime_ab, J_hund=J,
         off_diag=True, map_operator_structure=None, H_dump=None)
@@ -130,7 +129,7 @@ def test_quartic(verbose=False):
 
     if verbose:
         print('Ht_int_ref =', Ht_int_ref)
-    
+
     assert( (Ht_int_ref - Ht_int).is_zero() )
 
 # ----------------------------------------------------------------------
@@ -138,7 +137,7 @@ def test_single_particle_transform(verbose=False):
 
     if verbose:
         print('--> test_single_particle_transform')
-        
+
     h_loc = np.array([
         [1.0, 0.0],
         [0.0, -1.0],
@@ -179,7 +178,7 @@ def test_single_particle_transform(verbose=False):
         print('ht_loc_ref =\n', ht_loc_ref)
         print('Ht_loc =', Ht_loc)
         print('Ht_loc_ref =', Ht_loc_ref)
-    
+
     assert( (Ht_loc - Ht_loc_ref).is_zero() )
 
 # ----------------------------------------------------------------------
@@ -189,10 +188,10 @@ def test_quartic_tensor_from_operator(verbose=False):
     N = 3
     fundamental_operators = [ c(0, x) for x in range(N) ]
     shape = (N, N, N, N)
-    
+
     U = np.random.random(shape) + 1.j * np.random.random(shape)
     U_sym = symmetrize_quartic_tensor(U)
-    
+
     H = operator_from_quartic_tensor(U, fundamental_operators)
     U_ref = quartic_tensor_from_operator(H, fundamental_operators, perm_sym=True)
 

--- a/pyed/tests/test_sparse_matrix_fockstates.py
+++ b/pyed/tests/test_sparse_matrix_fockstates.py
@@ -1,9 +1,8 @@
-
-""" 
-Tests for conversion from Triqs expression to 
+"""
+Tests for conversion from Triqs expression to
 sparse matrix representation.
 
-Author: Hugo U. R. Strand (2017), hugo.strand@gmail.com 
+Author: Hugo U. R. Strand (2017), hugo.strand@gmail.com
 """
 
 # ----------------------------------------------------------------------
@@ -29,13 +28,13 @@ def compare_sparse_matrices(A, B):
     np.testing.assert_array_almost_equal(A.data, B.data)
     np.testing.assert_array_almost_equal(A.row, B.row)
     np.testing.assert_array_almost_equal(A.col, B.col)
-    
+
 # ----------------------------------------------------------------------
 def test_sparse_matrix_representation():
-    
+
     up, do = 0, 1
     fundamental_operators = [c(up,0), c(do,0)]
-    
+
     rep = SparseMatrixRepresentation(fundamental_operators)
 
     # -- Test an operator
@@ -61,7 +60,7 @@ def test_trimer_hamiltonian():
 
     # ------------------------------------------------------------------
     # -- Hubbard atom with two bath sites, Hamiltonian
-    
+
     beta = 2.0
     V1 = 2.0
     V2 = 5.0
@@ -71,7 +70,7 @@ def test_trimer_hamiltonian():
     U = 1.0
 
     # -- construction using triqs operators
-    
+
     up, do = 0, 1
     docc = c_dag(up,0) * c(up,0) * c_dag(do,0) * c(do,0)
     nA = c_dag(up,0) * c(up,0) + c_dag(do,0) * c(do,0)
@@ -82,15 +81,15 @@ def test_trimer_hamiltonian():
         V1 * (c_dag(up,0)*c(up,1) + c_dag(up,1)*c(up,0) + \
               c_dag(do,0)*c(do,1) + c_dag(do,1)*c(do,0) ) + \
         V2 * (c_dag(up,0)*c(up,2) + c_dag(up,2)*c(up,0) + \
-              c_dag(do,0)*c(do,2) + c_dag(do,2)*c(do,0) )    
+              c_dag(do,0)*c(do,2) + c_dag(do,2)*c(do,0) )
 
     # ------------------------------------------------------------------
     fundamental_operators = [
         c(up,0), c(do,0), c(up,1), c(do,1), c(up,2), c(do,2)]
-    
+
     rep = SparseMatrixRepresentation(fundamental_operators)
     H_mat = rep.sparse_matrix(H_expr)
-    
+
     # -- explicit construction
 
     class Dummy(object):
@@ -101,7 +100,7 @@ def test_trimer_hamiltonian():
     op.cdagger = rep.sparse_operators.c_dag
     op.c = np.array([cdag.getH() for cdag in op.cdagger])
     op.n = np.array([ cdag*cop for cop, cdag in zip(op.c, op.cdagger)])
-    
+
     H_ref = -mu * (op.n[0] + op.n[1]) + \
         epsilon1 * (op.n[2] + op.n[3]) + \
         epsilon2 * (op.n[4] + op.n[5]) + \
@@ -109,13 +108,13 @@ def test_trimer_hamiltonian():
         V1 * (op.cdagger[0] * op.c[2] + op.cdagger[2] * op.c[0] + \
               op.cdagger[1] * op.c[3] + op.cdagger[3] * op.c[1] ) + \
         V2 * (op.cdagger[0] * op.c[4] + op.cdagger[4] * op.c[0] + \
-              op.cdagger[1] * op.c[5] + op.cdagger[5] * op.c[1] )    
+              op.cdagger[1] * op.c[5] + op.cdagger[5] * op.c[1] )
 
     # ------------------------------------------------------------------
     # -- compare
 
     compare_sparse_matrices(H_mat, H_ref)
-    
+
 #----------------------------------------------------------------------
 if __name__ == '__main__':
 

--- a/pyed/tests/test_two_particle_greens_function.py
+++ b/pyed/tests/test_two_particle_greens_function.py
@@ -1,7 +1,6 @@
-
 """
 Solve a non-interacting three site problem and calculate
-its two-particle Green's function with both ED and Wicks theorem. 
+its two-particle Green's function with both ED and Wicks theorem.
 
 Author: Hugo U. R. Strand (2017), hugo.strand@gmail.com
 """
@@ -27,7 +26,7 @@ def test_two_particle_greens_function():
 
     # ------------------------------------------------------------------
     # -- Hubbard atom with two bath sites, Hamiltonian
-    
+
     beta = 2.0
     V1 = 2.0
     V2 = 5.0
@@ -47,13 +46,13 @@ def test_two_particle_greens_function():
               c_dag(do,0)*c(do,1) + c_dag(do,1)*c(do,0) ) + \
         V2 * (c_dag(up,0)*c(up,2) + c_dag(up,2)*c(up,0) + \
               c_dag(do,0)*c(do,2) + c_dag(do,2)*c(do,0) )
-    
+
     # ------------------------------------------------------------------
     # -- Exact diagonalization
 
     fundamental_operators = [
         c(up,0), c(do,0), c(up,1), c(do,1), c(up,2), c(do,2)]
-    
+
     ed = TriqsExactDiagonalization(H, fundamental_operators, beta)
 
     # ------------------------------------------------------------------
@@ -62,9 +61,9 @@ def test_two_particle_greens_function():
     g_tau = GfImTime(name=r'$g$', beta=beta,
                      statistic='Fermion', n_points=100,
                      target_shape=(1,1))
-    
+
     ed.set_g2_tau(g_tau[0, 0], c(up,0), c_dag(up,0))
-    
+
     # ------------------------------------------------------------------
     # -- Two particle Green's functions
 
@@ -84,7 +83,7 @@ def test_two_particle_greens_function():
     zero_outer_planes_and_equal_times(g4_tau)
     zero_outer_planes_and_equal_times(g40_tau)
     np.testing.assert_array_almost_equal(g4_tau.data, g40_tau.data)
-    
+
 #----------------------------------------------------------------------
 if __name__ == '__main__':
 

--- a/pyed/tests/transform_kanamori.py
+++ b/pyed/tests/transform_kanamori.py
@@ -1,6 +1,6 @@
 # ----------------------------------------------------------------------
 
-""" Kanamori interaction with transformed single particle basis. 
+""" Kanamori interaction with transformed single particle basis.
 
 Author: Gernot J. Kraberger (2016) """
 

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup
 setup(
-    name="pyed", 
+    name="pyed",
     packages=["pyed"],
     author="Hugo U.R. Strand",
     url="https://github.com/HugoStrand/pyed",


### PR DESCRIPTION
Currently Python spits out a `TabError` when loading pyed:

```python
  File "/tmp/source/pyed/ParameterCollection.py", line 34
    return list(self.__dict__.keys())
TabError: inconsistent use of tabs and spaces in indentation
```

In principle this patch is sufficient but for this PR I've taken the liberty to cleanup all whitespace across pyed.

```patch
diff --git a/pyed/ParameterCollection.py b/pyed/ParameterCollection.py
index 19d3efe..bc54673 100644
--- a/pyed/ParameterCollection.py
+++ b/pyed/ParameterCollection.py
@@ -31,7 +31,7 @@ class ParameterCollection(object):
         return list(self.__dict__.items())
 
     def keys(self):
-   	return list(self.__dict__.keys())
+        return list(self.__dict__.keys())
 
     def dict(self):
         return self.__dict__
```