### PR TITLE
remove superfluous reference removed from upstream

### DIFF
--- a/pyed/tests/test_operator_utils.py
+++ b/pyed/tests/test_operator_utils.py
@@ -13,7 +13,7 @@ import numpy as np
 
 from triqs.operators import n, c, c_dag, Operator, dagger
 
-from triqs.operators.util.U_matrix import U_matrix_kanamori, U_matrix
+from triqs.operators.util.U_matrix import U_matrix_kanamori
 from triqs.operators.util.hamiltonians import h_int_kanamori
 
 from transform_kanamori import h_int_kanamori_transformed


### PR DESCRIPTION
triqs renamed U_matrix to U_matrix_slater in https://github.com/TRIQS/triqs/commit/e7310c8cec45e2d1b536a5b5cdade46a347b27cb As such importing U_matrix breaks the operator test. Since U_matrix is just being imported and otherwise unused removing it allows the test to run properly again